### PR TITLE
Add fact counter

### DIFF
--- a/content/subject/economy/fact1.md
+++ b/content/subject/economy/fact1.md
@@ -1,6 +1,7 @@
 ---
 title: Brexit has already cost billions
 type: fact
+weight: 1
 ---
 
 The Bank of England has said that Brexit has already cost the UK £40 billion. That is around £900 per home.

--- a/content/subject/economy/fact2.md
+++ b/content/subject/economy/fact2.md
@@ -1,6 +1,7 @@
 ---
 title: We will be poorer in the long run
 type: fact
+weight: 2
 ---
 
 The Government estimates that the UK economy will be between 3.9% to 9.3% poorer over next 15 years if we go ahead with Brexit.

--- a/content/subject/immigration/fact1.md
+++ b/content/subject/immigration/fact1.md
@@ -1,6 +1,7 @@
 ---
 title: We control immigration from outside EU
 type: fact
+weight: 1
 ---
 
 As members of the EU, we are in complete control of immigration from countries outside the EU. We control immigration to the UK from 169 countries of the world.

--- a/content/subject/immigration/fact2.md
+++ b/content/subject/immigration/fact2.md
@@ -1,6 +1,7 @@
 ---
 title: We can control immigration from EU
 type: fact
+weight: 2
 ---
 
 EU law states that people from the EU must either have a job or enough money to not be a burden on the UK's public services and have medical insurance to be allowed to come and live here.

--- a/content/subject/immigration/fact3.md
+++ b/content/subject/immigration/fact3.md
@@ -1,6 +1,7 @@
 ---
 title: UK Nationals may have to leave the EU
 type: fact
+weight: 3
 ---
 
 If the UK leaves the EU, people from the UK will lose the automatic right to live, work and retire there. 1.2 million people from UK currently live in the EU. What will happen to them?

--- a/content/subject/immigration/fact4.md
+++ b/content/subject/immigration/fact4.md
@@ -1,6 +1,7 @@
 ---
 title: Immigrants give more than they take
 type: fact
+weight: 4
 ---
 
 On average, migrants from the EU contribute around £2,300 more to the UK than they take.

--- a/content/subject/immigration/fact5.md
+++ b/content/subject/immigration/fact5.md
@@ -1,6 +1,7 @@
 ---
 title: We need EU people to work in NHS
 type: fact
+weight: 5
 ---
 
 62,000 people from the EU currently work in the NHS.

--- a/content/subject/nhs/fact1.md
+++ b/content/subject/nhs/fact1.md
@@ -1,6 +1,7 @@
 ---
 title: There will be less money for NHS
 type: fact
+weight: 1
 ---
 
 Nearly all economists say we will be poorer after Brexit and so we are not going to get the extra £350 million a week for the NHS that we were promised. 

--- a/content/subject/nhs/fact2.md
+++ b/content/subject/nhs/fact2.md
@@ -1,6 +1,7 @@
 ---
 title: "We need EU people to work in NHS"
 type: fact
+weight: 2
 ---
 
 62,000 people from the EU currently work in the NHS.

--- a/content/subject/nhs/fact3.md
+++ b/content/subject/nhs/fact3.md
@@ -1,6 +1,7 @@
 ---
 title: EU migrants use the NHS less
 type: fact
+weight: 3
 ---
 
 Most EU migrants are young and healthy and so are less likely to use NHS.

--- a/content/subject/nhs/fact4.md
+++ b/content/subject/nhs/fact4.md
@@ -1,6 +1,7 @@
 ---
 title: We rely on EU for medicine
 type: fact
+weight: 4
 ---
 
 The UK imports 37 million packs of medicine each month from the EU. Some medicine don't keep for long so we need them to get here quickly and regularly. 

--- a/content/subject/sovereignty/fact1.md
+++ b/content/subject/sovereignty/fact1.md
@@ -1,6 +1,7 @@
 ---
 title: We are in control of the big things
 type: fact
+weight: 1
 ---
 
 In really important areas like taxation, allowing another country to join the EU or citizen’s rights and justice, if the UK does not agree to an idea that has come from the EU, we can stop it the EU from doing it.

--- a/content/subject/sovereignty/fact2.md
+++ b/content/subject/sovereignty/fact2.md
@@ -1,6 +1,7 @@
 ---
 title: We help decide what the EU will do
 type: fact
+weight: 2
 ---
 
 In less important areas, if the European Council want to do something they take a vote and need at least 50% of the countries to agree to it. 

--- a/content/subject/sovereignty/fact3.md
+++ b/content/subject/sovereignty/fact3.md
@@ -1,6 +1,7 @@
 ---
 title: We agree with the EU most of the time
 type: fact
+weight: 3
 ---
 
 The UK has only lost a vote against a suggested EU law 56 out of 2536 times since 1999, so for around 98% of the time we agree with the EU.

--- a/content/subject/sovereignty/fact4.md
+++ b/content/subject/sovereignty/fact4.md
@@ -1,6 +1,7 @@
 ---
 title: The single market is a good thing
 type: fact
+weight: 4
 ---
 
 The single market makes trade between EU companies easy by making all members keep to the same standards. 

--- a/content/subject/trade/fact1.md
+++ b/content/subject/trade/fact1.md
@@ -1,6 +1,7 @@
 ---
 title: The single market is a good thing
 type: fact
+weight: 1
 ---
 
 The single market makes trade between EU companies easy by making all members keep to the same standards. This means that we know the toasters produced in the UK, Germany or France are all of at least the same quality and so we don’t need to check them when they come in or out. This keeps us all safe and makes it much easier to do business in Europe.

--- a/content/subject/trade/fact2.md
+++ b/content/subject/trade/fact2.md
@@ -1,6 +1,7 @@
 ---
 title: We have a free trade deal with EU
 type: fact
+weight: 2
 ---
 
 As a member of the EU’s Single Market, we have free trade deals with all 27 EU countries. That is over 500 million customers. If we leave the Single Market, we will lose these agreements and will have to start negotiating with the EU again. 

--- a/content/subject/trade/fact3.md
+++ b/content/subject/trade/fact3.md
@@ -1,6 +1,7 @@
 ---
 title: We have free trade deals outside the EU
 type: fact
+weight: 3
 ---
 
 As part of the EU, we have free trade deals with over 50 countries outside of the EU from South Africa to South Korea. 

--- a/layouts/fact/single.html
+++ b/layouts/fact/single.html
@@ -13,7 +13,14 @@
     <div class="section-header">
         <div class="container">
             {{ $totalFacts := len ( where .CurrentSection.Pages "Type" "fact" ) }}
-            <h4>One of {{ $totalFacts }} facts</h4>
+            {{ $currentPermalink := .Permalink }}
+            {{ .Scratch.Add "countFact" 1 }}
+            {{ range .CurrentSection.Pages }}
+              {{ if eq .Permalink $currentPermalink }}
+                <h4>{{ .Scratch.Get "countFact" }} of {{ $totalFacts }} facts</h4>
+              {{ end }}
+              {{ .Scratch.Add "countFact" 1 }}
+            {{ end }}
 
             {{ with .CurrentSection }}
                 <p><a href="{{ .Permalink }}">See all facts</a></p>

--- a/layouts/fact/single.html
+++ b/layouts/fact/single.html
@@ -14,12 +14,13 @@
         <div class="container">
             {{ $totalFacts := len ( where .CurrentSection.Pages "Type" "fact" ) }}
             {{ $currentPermalink := .Permalink }}
-            {{ .Scratch.Add "countFact" 1 }}
-            {{ range .CurrentSection.Pages }}
+            {{ $scratch := newScratch }}
+            {{ $scratch.Add "countFact" 1 }}
+            {{ range .CurrentSection.Pages.ByWeight }}
               {{ if eq .Permalink $currentPermalink }}
-                <h4>{{ .Scratch.Get "countFact" }} of {{ $totalFacts }} facts</h4>
+                <h4>{{ $scratch.Get "countFact" }} of {{ $totalFacts }} facts</h4>
               {{ end }}
-              {{ .Scratch.Add "countFact" 1 }}
+              {{ $scratch.Add "countFact" 1 }}
             {{ end }}
 
             {{ with .CurrentSection }}


### PR DESCRIPTION
Fix #34 

Adds a counter to each fact.
Changes the weight on each fact so fact 1 is first, then 2 etc...
This adds weight front matter to each fact to keep them in the correct order (Hugo does it by date added first).
<img width="343" alt="screen shot 2018-12-30 at 2 38 55 pm" src="https://user-images.githubusercontent.com/1467480/50548233-fc30af00-0c40-11e9-80b1-263e1b86cd19.png">
