### PR TITLE
Add custom 404 page

### DIFF
--- a/layouts/404.html
+++ b/layouts/404.html
@@ -1,0 +1,24 @@
+{{ define "title" }}
+    <title>Page not found</title>
+{{ end }}
+
+{{ define "main" }}
+<section class="page-content page-content-404 container">
+  
+    <h2>Page not found!</h2>
+    <p>I'm sorry, the page your looking for was not found.</p>
+
+    {{ with .Site.GetPage "/_index.md" }}
+        <form action="{{ .Permalink }}">
+            <input type="submit" value="Go to the home page" class="button button-block" />
+        </form>
+    {{ end }}
+  
+    {{ with .Site.GetPage "/start/index.md" }}
+        <form action="{{ .Permalink }}">
+            <input type="submit" value="Show me the facts" class="button-inverse button-block" />
+        </form>
+    {{ end }}
+  
+</section>
+{{ end }}


### PR DESCRIPTION
fix #32

Adds the 404.html layout which (should) auto deploy to Netifly
as the custom 404 page.
404 text in page layout to avoid creating a /404 page in Hugo.

Signed-off-by: Andy Broomfield <andybroomfield@gmail.com>